### PR TITLE
Add interactive DUA concept map

### DIFF
--- a/dua-mapa/index.html
+++ b/dua-mapa/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mapa Conceptual Interactivo: Diseño Universal para el Aprendizaje</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <main class="page">
+        <header class="hero">
+            <h1>Mapa conceptual interactivo</h1>
+            <p>
+                Explora los elementos clave del <strong>Diseño Universal para el Aprendizaje (DUA)</strong>
+                seleccionando cada nodo del mapa. Haz clic en los conceptos para descubrir recomendaciones,
+                estrategias y ejemplos para poner en práctica.
+            </p>
+        </header>
+        <section class="map-section">
+            <div class="map-wrapper" aria-label="Mapa conceptual sobre el Diseño Universal para el Aprendizaje">
+                <svg class="connections" aria-hidden="true"></svg>
+                <button class="node node-central" data-node="central" aria-pressed="true">
+                    Diseño Universal para el Aprendizaje
+                </button>
+                <button class="node node-principios" data-node="principios" aria-pressed="false">
+                    Principios flexibles
+                </button>
+                <button class="node node-redes" data-node="redes" aria-pressed="false">
+                    Bases neurocientíficas
+                </button>
+                <button class="node node-estrategias" data-node="estrategias" aria-pressed="false">
+                    Estrategias didácticas
+                </button>
+                <button class="node node-planificacion" data-node="planificacion" aria-pressed="false">
+                    Planificación docente
+                </button>
+                <button class="node node-tecnologia" data-node="tecnologia" aria-pressed="false">
+                    Recursos y tecnología
+                </button>
+                <button class="node node-evaluacion" data-node="evaluacion" aria-pressed="false">
+                    Evaluación inclusiva
+                </button>
+                <button class="node node-beneficios" data-node="beneficios" aria-pressed="false">
+                    Impacto en el aula
+                </button>
+            </div>
+            <aside class="info-panel" aria-live="polite">
+                <h2 class="info-title">Diseño Universal para el Aprendizaje (DUA)</h2>
+                <p class="info-summary">
+                    Marco pedagógico que planifica la enseñanza desde la diversidad, eliminando barreras y
+                    ofreciendo múltiples alternativas para que todas las personas aprendan.
+                </p>
+                <ul class="info-list">
+                    <li>Proporciona flexibilidad en objetivos, métodos, materiales y evaluación.</li>
+                    <li>Se apoya en los aportes de la neurociencia sobre cómo aprendemos.</li>
+                </ul>
+            </aside>
+        </section>
+        <footer class="credits">
+            <p>
+                Elaborado como material de apoyo educativo. Puedes incorporar nuevos nodos y personalizarlo
+                para adaptarlo a las características de tu grupo.
+            </p>
+        </footer>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/dua-mapa/script.js
+++ b/dua-mapa/script.js
@@ -1,0 +1,182 @@
+const nodeDetails = {
+    central: {
+        title: "Diseño Universal para el Aprendizaje (DUA)",
+        description:
+            "Marco pedagógico que anticipa la diversidad desde el inicio, eliminando barreras y generando trayectorias flexibles para todo el alumnado.",
+        bullets: [
+            "Propone opciones múltiples en objetivos, métodos, materiales y evaluación para responder a estilos y ritmos de aprendizaje diversos.",
+            "Reconoce que todas las personas pueden aprender si se minimizan barreras físicas, sensoriales, cognitivas y culturales.",
+        ],
+    },
+    principios: {
+        title: "Principios flexibles del DUA",
+        description:
+            "Orientan la planificación de experiencias accesibles a través de tres grandes vías que se pueden combinar entre sí.",
+        bullets: [
+            "Compromiso: motivar, sostener el interés y ofrecer autonomía graduada en la participación estudiantil.",
+            "Representación: presentar los contenidos con múltiples formatos, lenguajes y apoyos para facilitar la comprensión.",
+            "Acción y expresión: habilitar diferentes formas de interacción y de demostrar lo aprendido, con apoyos y andamiajes.",
+        ],
+    },
+    redes: {
+        title: "Bases neurocientíficas",
+        description:
+            "El DUA se fundamenta en el funcionamiento de las redes de reconocimiento, estratégicas y afectivas del cerebro.",
+        bullets: [
+            "Red de reconocimiento: cómo percibimos la información, requiere variedad sensorial y claridad semántica.",
+            "Red estratégica: planifica y ejecuta acciones; necesita andamiajes, modelado y oportunidades de práctica.",
+            "Red afectiva: regula motivación y emociones; se potencia con propósito, relevancia y retroalimentación positiva.",
+        ],
+    },
+    estrategias: {
+        title: "Estrategias didácticas inclusivas",
+        description:
+            "El mapa invita a combinar estrategias activas y colaborativas que mantengan altas expectativas para todos los estudiantes.",
+        bullets: [
+            "Proporcionar guías visuales, anticipadores, bancos de recursos y ejemplos graduados.",
+            "Ofrecer opciones de trabajo individual, cooperativo y proyectos con elección auténtica.",
+            "Incorporar apoyos como organizadores gráficos, checklists y rúbricas comprensibles.",
+        ],
+    },
+    planificacion: {
+        title: "Planificación docente flexible",
+        description:
+            "Implica diseñar desde el inicio actividades, materiales y tiempos que contemplen variabilidad y apoyos escalonados.",
+        bullets: [
+            "Definir metas claras y retadoras que permitan diversas rutas de acceso y demostración.",
+            "Identificar barreras potenciales y prever alternativas de acceso, colaboración y expresión.",
+            "Documentar la secuencia didáctica en formatos abiertos que puedan adaptarse en tiempo real.",
+        ],
+    },
+    tecnologia: {
+        title: "Recursos y tecnología",
+        description:
+            "Las herramientas digitales, analógicas y de apoyo sensorial amplían las posibilidades de participación equitativa.",
+        bullets: [
+            "Seleccionar herramientas accesibles (lectores de pantalla, subtítulos, transcriptores, pictogramas, etc.).",
+            "Combinar recursos multimedia con materiales manipulables y experiencias concretas.",
+            "Fomentar la creación de contenidos por parte del estudiantado utilizando plantillas y formatos accesibles.",
+        ],
+    },
+    evaluacion: {
+        title: "Evaluación inclusiva y formativa",
+        description:
+            "La evaluación en clave DUA es continua, diversa y orientada a la mejora, evitando decisiones únicas y excluyentes.",
+        bullets: [
+            "Usar rúbricas, portfolios, registros de observación y autoevaluaciones que contemplen diferentes evidencias.",
+            "Acordar criterios visibles y comprensibles, con retroalimentación frecuente y orientada al proceso.",
+            "Permitir múltiples formas de demostrar logros: producciones orales, visuales, digitales, dramatizaciones, etc.",
+        ],
+    },
+    beneficios: {
+        title: "Impacto en el aula",
+        description:
+            "Implementar el DUA transforma la cultura escolar hacia la equidad y el aprendizaje profundo para todas las personas.",
+        bullets: [
+            "Disminuye la segregación y promueve la pertenencia, fortaleciendo el clima institucional.",
+            "Aumenta la participación y el protagonismo estudiantil al brindar apoyos graduados y autonomía.",
+            "Fortalece el trabajo colaborativo docente y la mirada interdisciplinar sobre la enseñanza.",
+        ],
+    },
+};
+
+const mapWrapper = document.querySelector(".map-wrapper");
+const connectionsSvg = document.querySelector(".connections");
+const nodes = Array.from(document.querySelectorAll(".node"));
+const centralNode = document.querySelector(".node-central");
+const infoTitle = document.querySelector(".info-title");
+const infoSummary = document.querySelector(".info-summary");
+const infoList = document.querySelector(".info-list");
+
+function renderInfo(nodeId) {
+    const data = nodeDetails[nodeId] ?? nodeDetails.central;
+    infoTitle.textContent = data.title;
+    infoSummary.textContent = data.description;
+
+    infoList.innerHTML = "";
+    data.bullets.forEach((item) => {
+        const li = document.createElement("li");
+        li.textContent = item;
+        infoList.appendChild(li);
+    });
+}
+
+function setActiveNode(selectedNode) {
+    nodes.forEach((node) => {
+        const isActive = node === selectedNode;
+        node.setAttribute("aria-pressed", isActive ? "true" : "false");
+        if (!node.classList.contains("node-central")) {
+            node.classList.toggle("node--active", isActive);
+        }
+    });
+}
+
+function updateConnections() {
+    if (!connectionsSvg || !mapWrapper) return;
+
+    const isHidden = window.getComputedStyle(connectionsSvg).display === "none";
+    connectionsSvg.innerHTML = "";
+
+    if (isHidden) {
+        return;
+    }
+
+    const wrapperRect = mapWrapper.getBoundingClientRect();
+    const centralRect = centralNode.getBoundingClientRect();
+    const centralPoint = {
+        x: centralRect.left - wrapperRect.left + centralRect.width / 2,
+        y: centralRect.top - wrapperRect.top + centralRect.height / 2,
+    };
+
+    connectionsSvg.setAttribute("viewBox", `0 0 ${wrapperRect.width} ${wrapperRect.height}`);
+    connectionsSvg.setAttribute("width", wrapperRect.width);
+    connectionsSvg.setAttribute("height", wrapperRect.height);
+
+    nodes.forEach((node) => {
+        if (node === centralNode) return;
+
+        const rect = node.getBoundingClientRect();
+        const nodePoint = {
+            x: rect.left - wrapperRect.left + rect.width / 2,
+            y: rect.top - wrapperRect.top + rect.height / 2,
+        };
+
+        const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+        line.setAttribute("x1", centralPoint.x);
+        line.setAttribute("y1", centralPoint.y);
+        line.setAttribute("x2", nodePoint.x);
+        line.setAttribute("y2", nodePoint.y);
+        line.setAttribute("stroke-linecap", "round");
+        line.classList.add("connection-line");
+        connectionsSvg.appendChild(line);
+    });
+}
+
+function handleNodeClick(event) {
+    const node = event.currentTarget;
+    const nodeId = node.dataset.node;
+    renderInfo(nodeId);
+    setActiveNode(node);
+}
+
+nodes.forEach((node) => {
+    node.addEventListener("click", handleNodeClick);
+});
+
+renderInfo("central");
+setActiveNode(centralNode);
+updateConnections();
+
+window.addEventListener("resize", () => {
+    window.requestAnimationFrame(updateConnections);
+});
+
+window.addEventListener("orientationchange", () => {
+    window.requestAnimationFrame(updateConnections);
+});
+
+window.addEventListener("load", () => {
+    updateConnections();
+});
+
+setTimeout(updateConnections, 250);

--- a/dua-mapa/styles.css
+++ b/dua-mapa/styles.css
@@ -1,0 +1,292 @@
+:root {
+    --bg-gradient: radial-gradient(circle at 20% 20%, #eef2ff 0%, #f9fbff 45%, #eef3ff 100%);
+    --primary: #1f3c88;
+    --accent: #ff9f1c;
+    --text: #1b1d29;
+    --panel-bg: rgba(255, 255, 255, 0.92);
+    --panel-border: rgba(23, 47, 102, 0.2);
+    --shadow: 0 22px 45px -25px rgba(21, 40, 90, 0.4);
+    --font-sans: "Rubik", "Segoe UI", "Poppins", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background: var(--bg-gradient);
+    color: var(--text);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+}
+
+.page {
+    width: min(1200px, 100%);
+    padding: 3rem clamp(1.2rem, 3vw, 3rem) 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+}
+
+.hero {
+    background: var(--panel-bg);
+    border-radius: 24px;
+    padding: clamp(1.8rem, 4vw, 2.6rem);
+    box-shadow: var(--shadow);
+    border: 1px solid var(--panel-border);
+}
+
+.hero h1 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    color: var(--primary);
+}
+
+.hero p {
+    margin: 0;
+    font-size: clamp(1.05rem, 2.4vw, 1.2rem);
+    line-height: 1.6;
+}
+
+.map-section {
+    display: flex;
+    gap: clamp(1.5rem, 3vw, 3rem);
+    align-items: stretch;
+    flex-wrap: wrap;
+}
+
+.map-wrapper {
+    position: relative;
+    flex: 1 1 55%;
+    min-width: min(550px, 100%);
+    aspect-ratio: 1 / 1;
+    background: rgba(255, 255, 255, 0.75);
+    border-radius: 28px;
+    padding: 2rem;
+    box-shadow: var(--shadow);
+    border: 1px solid rgba(31, 60, 136, 0.12);
+    overflow: hidden;
+}
+
+.map-wrapper::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(31, 60, 136, 0.12), transparent 65%);
+    pointer-events: none;
+}
+
+.connections {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    stroke: rgba(31, 60, 136, 0.35);
+    stroke-width: 2;
+}
+
+.connection-line {
+    stroke: rgba(31, 60, 136, 0.38);
+    stroke-width: 2.4;
+    stroke-dasharray: 8 10;
+}
+
+.node {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    min-width: 160px;
+    max-width: 210px;
+    padding: 0.85rem 1.2rem;
+    border-radius: 18px;
+    border: 2px solid var(--panel-border);
+    background: var(--panel-bg);
+    backdrop-filter: blur(8px);
+    color: var(--text);
+    font-weight: 600;
+    text-align: center;
+    cursor: pointer;
+    box-shadow: 0 20px 35px -25px rgba(23, 47, 102, 0.55);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease,
+        background-color 0.25s ease, color 0.25s ease;
+}
+
+.node:hover,
+.node:focus-visible {
+    transform: translate(-50%, -50%) scale(1.06);
+    box-shadow: 0 30px 50px -28px rgba(23, 47, 102, 0.6);
+    border-color: rgba(31, 60, 136, 0.55);
+}
+
+.node:focus-visible {
+    outline: 3px solid rgba(255, 159, 28, 0.8);
+    outline-offset: 4px;
+}
+
+.node-central {
+    font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+    padding: 1.2rem 1.4rem;
+    max-width: 260px;
+    background: linear-gradient(135deg, rgba(31, 60, 136, 0.92), rgba(76, 110, 231, 0.9));
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.45);
+    box-shadow: 0 25px 45px -25px rgba(31, 60, 136, 0.7);
+}
+
+.node--active:not(.node-central) {
+    background: linear-gradient(135deg, rgba(255, 159, 28, 0.95), rgba(255, 197, 94, 0.92));
+    color: #2b1b08;
+    border-color: rgba(255, 159, 28, 0.7);
+    box-shadow: 0 25px 45px -20px rgba(255, 159, 28, 0.55);
+}
+
+.node-principios {
+    top: 8%;
+    left: 50%;
+}
+
+.node-redes {
+    top: 24%;
+    left: 18%;
+}
+
+.node-estrategias {
+    top: 26%;
+    left: 82%;
+}
+
+.node-planificacion {
+    top: 52%;
+    left: 14%;
+}
+
+.node-tecnologia {
+    top: 55%;
+    left: 86%;
+}
+
+.node-evaluacion {
+    top: 85%;
+    left: 30%;
+}
+
+.node-beneficios {
+    top: 82%;
+    left: 72%;
+}
+
+.info-panel {
+    flex: 1 1 35%;
+    min-width: min(320px, 100%);
+    background: var(--panel-bg);
+    border-radius: 28px;
+    padding: clamp(1.6rem, 3vw, 2.4rem);
+    border: 1px solid var(--panel-border);
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.info-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 1.9rem);
+    color: var(--primary);
+}
+
+.info-summary {
+    margin: 0;
+    line-height: 1.65;
+    font-size: clamp(1.02rem, 2.2vw, 1.15rem);
+}
+
+.info-list {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.6rem;
+    font-size: clamp(0.95rem, 2vw, 1.05rem);
+}
+
+.info-list li {
+    line-height: 1.5;
+}
+
+.credits {
+    text-align: center;
+    font-size: 0.9rem;
+    color: rgba(27, 29, 41, 0.72);
+}
+
+@media (max-width: 1024px) {
+    .map-wrapper {
+        min-width: min(450px, 100%);
+        padding: 1.6rem;
+    }
+
+    .node {
+        min-width: 150px;
+    }
+}
+
+@media (max-width: 860px) {
+    .map-section {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .map-wrapper {
+        width: 100%;
+        aspect-ratio: auto;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1.5rem;
+        padding: clamp(1.5rem, 5vw, 2.2rem);
+    }
+
+    .connections {
+        display: none;
+    }
+
+    .node {
+        position: relative;
+        left: auto;
+        top: auto;
+        transform: none;
+        width: 100%;
+        min-height: 110px;
+        display: grid;
+        place-items: center;
+    }
+
+    .node:hover,
+    .node:focus-visible {
+        transform: scale(1.03);
+    }
+
+    .node-central {
+        order: -1;
+    }
+}
+
+@media (max-width: 540px) {
+    .page {
+        padding: 2.5rem 1rem 3rem;
+    }
+
+    .hero,
+    .info-panel {
+        border-radius: 20px;
+    }
+
+    .map-wrapper {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1.2rem;
+    }
+}


### PR DESCRIPTION
## Summary
- create a new HTML page that introduces an interactive concept map focused on el Diseño Universal para el Aprendizaje
- style the map with a responsive layout, highlighted nodes and SVG connections for large screens
- add JavaScript logic to render concept descriptions, highlight selections and recalculate connection lines on resize

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8fe81fe9c8325bc3f0fe92785899d