### PR TITLE
Agregar programa imprimible para verificación de textos IA

### DIFF
--- a/programa-verificacion-textos-ia.md
+++ b/programa-verificacion-textos-ia.md
@@ -1,0 +1,155 @@
+# Programa de verificación rápida de textos potencialmente escritos con IA
+
+**Objetivo general:** ofrecer a docentes universitarios una guía breve, imprimible y estandarizada para detectar indicios de uso no declarado de herramientas de inteligencia artificial generativa en producciones académicas.
+
+---
+
+## 1. Preparación previa
+- Tené a mano el trabajo del estudiante y, si existe, una versión previa realizada por la misma persona.
+- Disponé de los materiales obligatorios de la cursada (programa, bibliografía, consignas) para cotejar datos.
+- Acordá con la cátedra la política de uso y declaración de IA antes de aplicar esta guía.
+
+---
+
+## 2. Checklist de indicios (marcá lo que observes)
+> **Regla de oro:** ningún indicio aislado basta. Actuá solo frente a la concurrencia de señales.
+
+### A. Forma y ortotipografía
+[ ] Título con mayúsculas de estilo inglés (Title Case) en lugar de frase española (p. ej., *La Educación En El Aula* en vez de *La educación en el aula*).
+
+[ ] Mayúscula después de dos puntos en una oración corrida (calco del inglés).
+
+[ ] Listas con viñetas excesivamente simétricas/parejas; mismos patrones en la longitud de cada ítem.
+
+[ ] Emojis o tono “amable” en contexto formal sin que la consigna lo pida.
+
+[ ] Comillas o puntuación anglo: comillas dobles rectas (""), uso poco común de punto y coma (;), conectores como encabezado de párrafo (*Además:*, *Sin embargo:*).
+
+[ ] Ampersand (&) en la lista de referencias (en español corresponde escribir “y”).
+
+[ ] Coma antes de la conjunción “y” en enumeraciones salvo ambigüedades (Oxford comma).
+
+### B. Marcas discursivas y léxico comodín
+[ ] Abundancia de comodines: *tensión, impacto, desafío, complejidad, transformación, panorama, entramado, significativo, robusto*.
+
+[ ] Muletillas de ensamblado: *por un lado/por otro, en este sentido, cabe destacar, a nivel de, en definitiva*.
+
+[ ] Cierres estandarizados (“en conclusión”) sin necesidad argumental.
+
+### C. Contenido verificable
+[ ] Bibliografía perfecta pero dudosa: DOIs/ISBNs inexistentes, páginas inventadas, títulos plausibles sin rastro.
+
+[ ] Datos verificables sin fuente o descontextualizados.
+
+[ ] Alucinaciones: afirmaciones específicas difíciles de confirmar o directamente inexistentes.
+
+### D. Consistencia autoral
+[ ] Salto abrupto respecto de textos previos del mismo estudiante (sintaxis, densidad de conectores, precisión léxica, variedad rioplatense).
+
+[ ] Uniformidad estilística anómala (todo “limado”, sin huellas personales ni ejemplos situados).
+
+[ ] Traduccionalidad encubierta: calcos del inglés (*aplicar para, basado en evidencia, soportar una teoría*).
+
+---
+
+## 3. Protocolo de verificación en 10 minutos
+Aplicar únicamente si se detectan varios indicios. Registrá cada paso de manera breve.
+
+1. **Minidefensa oral (3–4 min)**  
+   Pedí: “Explicá con tus palabras qué sostienen el 2.º y 3.º párrafo; agregá un ejemplo de nuestra cursada”.  
+   *Indicador positivo:* detalles situados (actividad, fecha, autor del programa, página).
+
+2. **Reformulación situada (2–3 min)**  
+   Instrucción: “Reescribí este párrafo aplicándolo a [tema local del curso]; citá un autor del programa y una página”.  
+   *Falla típica:* paginación errónea, cita genérica, falta de anclaje local.
+
+3. **Chequeo de referencias (2–3 min)**  
+   Elegí dos citas al azar y pedí página, editorial, año y dos ideas clave del texto citado.  
+   Verificá al menos un DOI o ISBN.
+
+4. **Microtarea en vivo (2–3 min)**  
+   Solicitá: “Derivá una implicancia para [actividad de la cátedra] y justificá con un concepto visto en clase”.  
+   *Rastro de autoría:* idiolecto del estudiante, conexión con materiales de la cursada.
+
+**Cierre:** documentá el resultado (suficiente/insuficiente) y definí próximos pasos pedagógicos.
+
+---
+
+## 4. Rúbrica breve de despistaje (orientativa, no sancionatoria)
+Cada casilla marcada en la checklist equivale a 1 punto.
+
+| Dimensión            | Evidencias típicas                                                                 | Puntaje (0–2/3) |
+|----------------------|-------------------------------------------------------------------------------------|-----------------|
+| Forma en español     | Title Case, mayúsculas tras “:”, listas clonadas, comillas/puntuación anglo         | ____ / 7        |
+| Discurso             | Comodines, conectores repetidos, cierres “de manual”, estructura rígida            | ____ / 3        |
+| Contenido verificable| Referencias dudosas, datos sin fuente, incoherencia con el programa                | ____ / 3        |
+| Consistencia autoral | Ruptura con textos previos, oralización débil                                      | ____ / 3        |
+
+**Interpretación orientativa:**
+- 0 a 3 puntos → Señales bajas. Probable autoría genuina, salvo dudas puntuales.
+- 4 a 7 puntos → Señales moderadas. Conviene pedir aclaraciones al estudiante.
+- 8 a 11 puntos → Señales altas. Aplicar protocolo de verificación (defensa oral, reformulación, chequeo de referencias).
+- 12 a 16 puntos → Señales muy altas. Alta probabilidad de uso de IA sin declarar; documentar y abordar pedagógicamente.
+
+---
+
+## 5. Falsos positivos frecuentes (para no equivocarte)
+- Estudiantes muy prolijos que usan plantillas o gestores bibliográficos.
+- Títulos en Title Case por plantillas de Word o hábitos ofimáticos.
+- Estilo excesivamente formal por imitación de papers.
+- Estudiantes bilingües o no nativos que transfieren patrones del inglés.
+
+---
+
+## 6. Enfoque pedagógico si se confirma uso no declarado
+- Exigir una política de declaración explícita (qué, cómo y con qué herramienta se usó IA).
+- Evaluar el proceso: pedir bitácoras de versión, notas de lectura con citas verificables y breves defensas orales.
+- Diseñar consignas “a prueba de IA genérica”: solicitar ejemplos locales, análisis de materiales de clase, datos de actividades propias y fuentes proporcionadas por la cátedra.
+- Acordar con el equipo docente los pasos de acompañamiento (reelaboración guiada, instancia evaluativa alternativa, entrevista pedagógica).
+
+---
+
+## 7. Plantilla imprimible de registro
+```
+Ficha de verificación de producción académica
+
+Asignatura:  ___________________________________________
+Profesor/a: ______________________   Comisión: __________   Fecha: ________________
+Estudiante: ____________________________________________
+Trabajo: _______________________________________________
+
+Criterios observados (marcar):
+   A (formato) [ ]     B (estilo) [ ]     C (contenido) [ ]     D (consistencia) [ ]
+Descripción breve:
+_______________________________________________________________________________
+_______________________________________________________________________________
+
+Protocolo aplicado:
+1. Defensa oral — Resultado:  ✔  /  ✖
+   Observaciones:
+   ____________________________________________________________________________
+
+2. Reformulación situada — Resultado:  ✔  /  ✖
+   Observaciones:
+   ____________________________________________________________________________
+
+3. Chequeo de referencias — Resultado:  ✔  /  ✖
+   Observaciones:
+   ____________________________________________________________________________
+
+4. Microtarea en vivo — Resultado:  ✔  /  ✖
+   Observaciones:
+   ____________________________________________________________________________
+
+Conclusión orientativa de la rúbrica (0–16): __________
+Decisiones pedagógicas (reelaboración, entrevista, instancia alternativa, etc.):
+_______________________________________________________________________________
+_______________________________________________________________________________
+
+Consejo final: usá esta ficha para guiar conversaciones justas y formativas. El objetivo no es
+“cazar”, sino fortalecer la honestidad académica y acompañar la autoría estudiantil.
+```
+
+---
+
+**Sugerencia de impresión:** formato A4, doble faz opcional. Conservá copias digitales y físicas para el seguimiento del proceso formativo.


### PR DESCRIPTION
## Summary
- crear un programa imprimible para la verificación rápida de textos potencialmente escritos con IA
- compilar en un único documento checklist, protocolo breve, rúbrica, alertas de falsos positivos y plantilla de registro

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9af54e6a483258c952b21b54d93b7